### PR TITLE
Added alphanumeric mask, allowing spaces.

### DIFF
--- a/lib/vanilla-masker.js
+++ b/lib/vanilla-masker.js
@@ -85,6 +85,11 @@
     this.opts = {};
     this.bindElementToMask("toNumber");
   };
+  
+  VanillaMasker.prototype.maskAlphaNum = function() {
+    this.opts = {};
+    this.bindElementToMask("toAlphaNumeric");
+  };
 
   VanillaMasker.prototype.maskPattern = function(pattern) {
     this.opts = {pattern: pattern};
@@ -175,6 +180,10 @@
 
   VMasker.toNumber = function(value) {
     return value.toString().replace(/(?!^-)[^0-9]/g, "");
+  };
+  
+  VMasker.toAlphaNumeric = function(value) {
+    return value.toString().replace(/[^a-z0-9 ]+/i, "");
   };
 
   return VMasker;


### PR DESCRIPTION
To use:

```javascript
var el = document.getElementById("someInput");
VMasker(el).maskAlphaNum();
```