### PR TITLE
Add optional placeholder feature for patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ VMasker.toPattern(99911111101, "999.999.999-99"); // -> 999.111.111-01
 VMasker.toPattern('ABC1234', "AAA-9999"); // -> ABC-1234
 // Converts value to masked vehicle identification
 VMasker.toPattern('9BGRD08X04G117974', "SS.SS.SSSSS.S.S.SSSSSS"); // -> 9B.GR.D08X0.4.G.117974
+
+// Pass in an optional placeholder option to represent remaining characters to be entered
+VMasker.toPattern('4', {pattern: "(999) 999-9999", placeholder: "x"}); // -> (4xx) xxx-xxxx
 ```
 
 #### Undoing a mask

--- a/lib/vanilla-masker.js
+++ b/lib/vanilla-masker.js
@@ -32,6 +32,15 @@
         };
         opts.moneyPrecision = opts.zeroCents ? 0 : opts.precision;
         return opts;
+      },
+      // Fill wildcards past index in output with placeholder
+      addPlaceholdersToOutput = function(output, index, placeholder) {
+        for (; index < output.length; index++) {
+          if(output[index] === DIGIT || output[index] === ALPHA || output[index] === ALPHANUM) {
+            output[index] = placeholder;
+          }
+        }
+        return output;
       }
   ;
 
@@ -160,22 +169,37 @@
         charsValues = values.replace(/\W/g, ''),
         index = 0,
         i,
-        outputLength = output.length
+        outputLength = output.length,
+        placeholder = (typeof opts === 'object' ? opts.placeholder : undefined)
     ;
     
     for (i = 0; i < outputLength; i++) {
+      // Reached the end of input
       if (index >= values.length) {
         if (patternChars.length == charsValues.length) {
           return output.join("");
         }
-        break;
+        else if ((placeholder !== undefined) && (patternChars.length > charsValues.length)) {
+          return addPlaceholdersToOutput(output, i, placeholder).join("");
+        }
+        else {
+          break;
+        }
       }
-      if ((output[i] === DIGIT && values[index].match(/[0-9]/)) ||
-          (output[i] === ALPHA && values[index].match(/[a-zA-Z]/)) ||
-          (output[i] === ALPHANUM && values[index].match(/[0-9a-zA-Z]/))) {
-        output[i] = values[index++];
-      } else if (output[i] === DIGIT || output[i] === ALPHA || output[i] === ALPHANUM) {
-        output = output.slice(0, i);
+      // Remaining chars in input
+      else{
+        if ((output[i] === DIGIT && values[index].match(/[0-9]/)) ||
+            (output[i] === ALPHA && values[index].match(/[a-zA-Z]/)) ||
+            (output[i] === ALPHANUM && values[index].match(/[0-9a-zA-Z]/))) {
+          output[i] = values[index++];
+        } else if (output[i] === DIGIT || output[i] === ALPHA || output[i] === ALPHANUM) {
+          if(placeholder !== undefined){
+            return addPlaceholdersToOutput(output, i, placeholder).join("");
+          }
+          else{
+            return output.slice(0, i).join("");
+          }
+        }
       }
     }
     return output.join("").substr(0, i);

--- a/tests/pattern_spec.js
+++ b/tests/pattern_spec.js
@@ -83,4 +83,22 @@ describe("VanillaMasker.toPattern", function() {
   it('returns "BB.G" pattern when input is 9BG', function() {
     expect(VMasker.toPattern('BBG', 'SS.SS.SSSSS.S.S.SSSSSS')).toEqual('BB.G');
   });
+
+  it('returns "(4xx) xxx-xxxx" when input is 4 and placeholder is x', function(){
+    expect(VMasker.toPattern('4', {pattern: "(999) 999-9999", placeholder: "x"})).toEqual('(4xx) xxx-xxxx');
+  });
+
+  it('returns "(___) ___-_____" when input is empty and placeholder is _', function(){
+    expect(VMasker.toPattern('', {pattern: "(999) 999-9999", placeholder: "_"})).toEqual('(___) ___-____');
+  });
+
+  it('returns "(111) 111-1111" when input is 1111111111 and placeholder is _', function(){
+    expect(VMasker.toPattern('1111111111', {pattern: "(999) 999-9999", placeholder: "_"})).toEqual('(111) 111-1111');
+  });
+
+  it('returns "(aaa) _____" when input is aaa999aaaa and placeholder is _', function(){
+    expect(VMasker.toPattern('aaa999aaaa', {pattern: "(AAA) AAAAA", placeholder: "_"})).toEqual('(aaa) _____');
+  });
+
+
 });


### PR DESCRIPTION
<code>toPattern</code> can now take in an optional placeholder value. This placeholder will be used to represent characters that remain to be entered.

For instance, 
<code>VMasker.toPattern('4', {pattern: "(999) 999-9999", placeholder: "x"}); // -> (4xx) xxx-xxxx</code>

If no placeholder is specified, behavior is the same as before.

Updated README and unit tests, and all tests pass.