### PR TITLE
Expose `vanilla-masker` to `require`, so it can be used with browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "vanilla-masker",
   "version": "1.0.6",
   "description": "VanillaMasker is a pure javascript input mask.",
+  "main": "lib/vanilla-masker.js",
   "scripts": {
     "start": "grunt dev",
     "build": "grunt build",


### PR DESCRIPTION
- it currently can't be required because there's no `index.js` file