### PR TITLE
Beautify demo page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<title>VanillaMasker</title>
 		<script src="/vanilla-masker.js"></script>
+		<link rel="stylesheet" type="text/css" href="styles.css">
 	</head>
 	<body>
 		<h1>VanillaMasker</h1>
@@ -10,25 +11,25 @@
 		<fieldset>
 			<legend>VMasker(element).maskMoney(options);</legend>
 
-			<h4>Default</h4>
+			<label for="default">Default</label>
 			<input type="text" id="default" maxlength="7">
 
-			<h4>Zero cents</h4>
+			<label for="zeroCents">Zero cents</label>
 			<input type="text" id="zeroCents">
 
-			<h4>Unit R$</h4>
+			<label for="unit">Unit R$</label>
 			<input type="text" id="unit">
 
-			<h4>Suffix Unit R$</h4>
+			<label for="suffixUnit">Suffix unit R$</label>
 			<input type="text" id="suffixUnit">
 
-			<h4>Delimiter ","</h4>
+			<label for="delimiter">Delimiter ","</label>
 			<input type="text" id="delimiter">
 
-			<h4>Separator "."</h4>
+			<label for="separator">Separator "."</label>
 			<input type="text" id="separator">
 
-			<h4>Default with values</h4>
+			<label for="defaultValues">Default with values</label>
 			<input type="text" id="defaultValues" value="1000">
 		</fieldset>
 
@@ -37,7 +38,7 @@
 		<fieldset>
 			<legend>VMasker(element).maskNumber();</legend>
 
-			<h4>Only numbers</h4>
+			<label for="numbers">Only numbers</label>
 			<input type="text" id="numbers">
 		</fieldset>
 
@@ -46,22 +47,22 @@
 		<fieldset>
 			<legend>VMasker(element).maskPattern(pattern);</legend>
 
-			<h4>Phone</h4>
+			<label for="phone">Phone</label>
 			<input type="text" id="phone">
 
-			<h4>Phone with values</h4>
+			<label for="phoneValues">Phone with values</label>
 			<input type="text" id="phoneValues" value="3141232312">
 
-			<h4>Date</h4>
+			<label for="date">Date</label>
 			<input type="text" id="date">
 
-			<h4>Document</h4>
+			<label for="doc">Document</label>
 			<input type="text" id="doc">
 
-			<h4>Car plate</h4>
+			<label for="carPlate">Car plate</label>
 			<input type="text" id="carPlate">
 
-			<h4>Vehicle Identification</h4>
+			<label for="vin">Vehicle Identification</label>
 			<input type="text" id="vin">
 		</fieldset>
 

--- a/public/index.html
+++ b/public/index.html
@@ -62,8 +62,8 @@
 			<label for="carPlate">Car plate</label>
 			<input type="text" id="carPlate">
 
-			<label for="vin">Vehicle identification</label>
-			<input type="text" id="vin">
+			<label for="vid">Vehicle identification</label>
+			<input type="text" id="vid">
 		</fieldset>
 
 		<script>
@@ -86,7 +86,7 @@
 				VMasker(document.getElementById("date")).maskPattern('99/99/9999');
 				VMasker(document.getElementById("doc")).maskPattern('999.999.999-99');
 				VMasker(document.getElementById("carPlate")).maskPattern('AAA-9999');
-				VMasker(document.getElementById("vin")).maskPattern('SS.SS.SSSSS.S.S.SSSSSS');
+				VMasker(document.getElementById("vid")).maskPattern('SS.SS.SSSSS.S.S.SSSSSS');
 			})();
 		</script>
 	</body>

--- a/public/index.html
+++ b/public/index.html
@@ -62,7 +62,7 @@
 			<label for="carPlate">Car plate</label>
 			<input type="text" id="carPlate">
 
-			<label for="vin">Vehicle Identification</label>
+			<label for="vin">Vehicle identification</label>
 			<input type="text" id="vin">
 		</fieldset>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,36 @@
+body {
+  font-family: helvetica, arial
+}
+h1 {
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+}
+input {
+  height: 2em;
+  border: 1px solid;
+  border-color: #AAAAAA;
+  padding-left: 0.5em;
+}
+legend {
+  font-style: italic;
+}
+fieldset {
+  max-width: 30%;
+  margin-left: auto;
+  margin-right: auto;
+}
+label, input {
+  display: block;
+  width: 95%;
+  margin-left: auto;
+  margin-right: auto;
+}
+input, legend {
+  margin-bottom: 1em;
+}
+input, fieldset {
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  border-radius: 8px;
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -29,7 +29,5 @@ input, legend {
   margin-bottom: 1em;
 }
 input, fieldset {
-  -webkit-border-radius: 8px;
-  -moz-border-radius: 8px;
   border-radius: 8px;
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -8,8 +8,7 @@ h1 {
 }
 input {
   height: 2em;
-  border: 1px solid;
-  border-color: #AAAAAA;
+  border: 1px solid #aaa;
   padding-left: 0.5em;
 }
 legend {


### PR DESCRIPTION
In conformance with TODO list on VanillaMasker's page, I'm sending this pull request to improve  demo page's layout.

- centralize the "form" and adjust it's width;
- change h4 tags to label tags and add "for" attribute;
- add spaces between fields;
- increase height, add radius and border of input fields; 
- use sans-serif fonts;
- change legend to italic;
- standardize case;

I've tried to centralize legend content but I read this tag is not standardized amoung browsers. Some people say it's better to use a h tag instead. What do you think?

How demo page is now: http://bankfacil.github.io/vanilla-masker/demo.html 

Proposal:
![vanillamasker demo page](https://cloud.githubusercontent.com/assets/704119/7902323/99b32ad6-078c-11e5-80b6-df431d3af2f1.png)

