### PR TITLE
Bug fix for `npm i vanilla-masker` on windows machines

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+bankfacil:vanilla-masker


### PR DESCRIPTION
Added .npmignore so that the folder `bankfacil:vanilla-masker` won't be unpackaged
 - on windows machines `:` are prohibited on the path

On windows machines folders with a double colon will result in an error during unpacking of the module. I don't think you need that folder when installed via `npm` and added the folder to the `npm-ignore`. 